### PR TITLE
Fix end time logic in EventContext

### DIFF
--- a/src/contexts/EventContext.jsx
+++ b/src/contexts/EventContext.jsx
@@ -95,8 +95,11 @@ export function EventContextProvider({ children }) {
         const startTime = data.startTime;
         const [startHours, startMinutes] = startTime.split(':').map(Number);
         const [endHours, endMinutes] = prevEventData.endTime.split(':').map(Number);
-        
-        if (startHours >= endHours && startMinutes >= endMinutes) {
+
+        const startTotal = startHours * 60 + startMinutes;
+        const endTotal = endHours * 60 + endMinutes;
+
+        if (startTotal >= endTotal) {
           updatedData.endTime = getEndTime(startTime);
         }
       }


### PR DESCRIPTION
## Summary
- ensure that EventContext correctly updates end times when start time moves past the original end time

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684176359f00833385f1c78de1b45b9a